### PR TITLE
compatibility with wxPython Phoenix

### DIFF
--- a/wxAnyThread/__init__.py
+++ b/wxAnyThread/__init__.py
@@ -83,14 +83,14 @@ class MethodInvocationEvent(wx.PyEvent):
             exception = self.event.exception
             traceback = self.event.traceback
             del self.event.traceback
-            raise type(exception), exception, traceback
+            raise type(exception)(exception).with_traceback(traceback)
 
     def process(self):
         """Execute the method and signal that it is ready."""
         try:
             result = self.func(*self.args, **self.kwds)
             self.event.result = result
-        except Exception, e:
+        except:
             self.event.set_exc_info(sys.exc_info())
 
         self.event.set()


### PR DESCRIPTION
the trick to make it work with wxPython Phoenix is to move the members 'exception' and 'traceback' of MethodInvocationEvent to a separate class. It seems that due to the new underlying wrapper technology, wx.PyEvent behaves differently and it is not possible anymore to overwrite / set new members in derived classes.

The solution should also work with older versions of wxPython.